### PR TITLE
fix: upgrade non deterministic gas

### DIFF
--- a/x/upgrade/abci.go
+++ b/x/upgrade/abci.go
@@ -22,6 +22,7 @@ import (
 // skipUpgradeHeightArray is a set of block heights for which the upgrade must be skipped
 func BeginBlocker(k *keeper.Keeper, ctx sdk.Context, _ abci.RequestBeginBlock) {
 	defer telemetry.ModuleMeasureSince(types.ModuleName, time.Now(), telemetry.MetricKeyBeginBlocker)
+	ctx = ctx.WithBlockGasMeter(sdk.NewInfiniteGasMeter()).WithGasMeter(sdk.NewInfiniteGasMeter())
 
 	plan, found := k.GetUpgradePlan(ctx)
 
@@ -80,7 +81,6 @@ func BeginBlocker(k *keeper.Keeper, ctx sdk.Context, _ abci.RequestBeginBlock) {
 
 		// We have an upgrade handler for this upgrade name, so apply the upgrade
 		ctx.Logger().Info(fmt.Sprintf("applying upgrade \"%s\" at %s", plan.Name, plan.DueAt()))
-		ctx = ctx.WithBlockGasMeter(sdk.NewInfiniteGasMeter())
 		k.ApplyUpgrade(ctx, plan)
 		return
 	}


### PR DESCRIPTION
the same reason as for https://github.com/neutron-org/cosmos-sdk/pull/9
do not count gas in upgrade module begin blocker due to nondetermenistic gas accounting.